### PR TITLE
Group equal DNS names into same endpoint

### DIFF
--- a/source/node_test.go
+++ b/source/node_test.go
@@ -128,6 +128,19 @@ func testNodeSourceEndpoints(t *testing.T) {
 			false,
 		},
 		{
+			"node with fqdn template returns two endpoints with multiple IP addresses and expanded hostname",
+			"",
+			"{{.Name}}.example.org",
+			"node1",
+			[]v1.NodeAddress{{v1.NodeExternalIP, "1.2.3.4"}, {v1.NodeExternalIP, "5.6.7.8"}},
+			map[string]string{},
+			map[string]string{},
+			[]*endpoint.Endpoint{
+				{RecordType: "A", DNSName: "node1.example.org", Targets: endpoint.Targets{"1.2.3.4", "5.6.7.8"}},
+			},
+			false,
+		},
+		{
 			"node with both external and internal IP returns an endpoint with external IP",
 			"",
 			"",


### PR DESCRIPTION
If `NodeSource` generates endpoints where the same DNS name maps to multiple IPs, group them into the same endpoint so that the providers can create them correctly.

This can happen when using a static fqdn template (e.g. to expose all nodes in DNS under the same dns name) or when a node has multiple external IPs.